### PR TITLE
[#6] 사장은 매장 등록을 위해 가게 상호명, 업종, 사업자 번호 등을 입력하고 수정할 수 있다 (#6)

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -95,6 +95,7 @@ jobs:
             echo "JWT_ISSUER=${{ secrets.JWT_ISSUER }}" >> .env
             echo "KAKAO_CLIENT_ID=${{ secrets.KAKAO_CLIENT_ID }}" >> .env
             echo "KAKAO_REDIRECT_URI=${{ secrets.KAKAO_REDIRECT_URI }}" >> .env
+            echo "BUSINESS_API_KEY=${{ secrets.BUSINESS_API_KEY }}" >> .env
             echo "${{ secrets.DOCKERHUB_PASSWORD }}" | docker login -u "${{ secrets.DOCKERHUB_USERNAME }}" --password-stdin
             docker compose down -v
             docker images -q ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.PROJECT_NAME }}-app:latest | grep -q . && docker rmi ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.PROJECT_NAME }}-app:latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,18 +10,6 @@ jobs:
   build-app:
     runs-on: ubuntu-latest
 
-    env:
-      DB_URL: ${{ secrets.DB_URL }}
-      DB_USERNAME: ${{ secrets.DB_USERNAME }}
-      DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
-      JWT_SECRET: ${{ secrets.JWT_SECRET }}
-      JWT_ACCESS_EXPIRATION: ${{ secrets.JWT_ACCESS_EXPIRATION }}
-      JWT_REFRESH_EXPIRATION: ${{ secrets.JWT_REFRESH_EXPIRATION }}
-      JWT_ISSUER: ${{ secrets.JWT_ISSUER }}
-      KAKAO_CLIENT_ID: ${{ secrets.KAKAO_CLIENT_ID }}
-      KAKAO_REDIRECT_URI: ${{ secrets.KAKAO_REDIRECT_URI }}
-      BUSINESS_API_KEY: ${{ secrets.BUSINESS_API_KEY }}
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
       JWT_ISSUER: ${{ secrets.JWT_ISSUER }}
       KAKAO_CLIENT_ID: ${{ secrets.KAKAO_CLIENT_ID }}
       KAKAO_REDIRECT_URI: ${{ secrets.KAKAO_REDIRECT_URI }}
+      BUSINESS_API_KEY: ${{ secrets.BUSINESS_API_KEY }}
 
     steps:
       - name: Checkout repository

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -24,6 +24,11 @@ dependencies {
 
     runtimeOnly 'mysql:mysql-connector-java:8.0.32'
 
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'  // WebClient 사용 시 필요
+    implementation 'com.fasterxml.jackson.core:jackson-databind'
+
+    implementation 'org.apache.commons:commons-lang3:3.12.0' // 매장 초대 코드 생성
+
     implementation 'commons-net:commons-net:3.6'
     implementation project (':storage')
 }

--- a/app/src/main/java/com/mangoboss/app/ExternalBusinessApiClient.java
+++ b/app/src/main/java/com/mangoboss/app/ExternalBusinessApiClient.java
@@ -1,0 +1,54 @@
+package com.mangoboss.app;
+
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.mangoboss.app.common.exception.CustomErrorInfo;
+import com.mangoboss.app.common.exception.CustomException;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@RequiredArgsConstructor
+@Component
+@Slf4j
+public class ExternalBusinessApiClient {
+
+	@Value("${external.business-api.key}")
+	private String businessApiKey;
+
+	private final WebClient webClient = WebClient.builder()
+		.baseUrl("https://api.odcloud.kr/api/nts-businessman/v1")
+		.build();
+
+	// 사업자번호 유효성 확인 API (상태조회)
+	public boolean checkBusinessNumberValid(String businessNumber) {
+		try {
+			Map<String, Object> body = Map.of("b_no", List.of(businessNumber));
+
+			JsonNode response = webClient.post()
+				.uri(uriBuilder -> uriBuilder
+					.path("/status")
+					.queryParam("serviceKey", businessApiKey)
+					.queryParam("returnType", "JSON")
+					.build())
+				.bodyValue(body)
+				.retrieve()
+				.bodyToMono(JsonNode.class)
+				.block(); // 동기 방식 (Spring WebFlux 안 쓸 경우 안전)
+			log.info(response.toString());
+
+			JsonNode statusNode = response.path("data").get(0).path("b_stt");
+
+			return statusNode != null && !statusNode.asText().isBlank();
+
+		} catch (Exception e) {
+			throw new CustomException(CustomErrorInfo.BUSINESS_API_FAILED);
+		}
+	}
+}

--- a/app/src/main/java/com/mangoboss/app/api/controller/store/BossStoreController.java
+++ b/app/src/main/java/com/mangoboss/app/api/controller/store/BossStoreController.java
@@ -1,4 +1,4 @@
-package com.mangoboss.app.api.controller.store.boss;
+package com.mangoboss.app.api.controller.store;
 
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -7,7 +7,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.mangoboss.app.api.facade.store.boss.BossStoreFacade;
+import com.mangoboss.app.api.facade.store.BossStoreFacade;
 import com.mangoboss.app.common.exception.CustomUserDetails;
 import com.mangoboss.app.dto.store.request.BusinessNumberRequest;
 import com.mangoboss.app.dto.store.request.StoreCreateRequest;
@@ -21,17 +21,17 @@ import lombok.RequiredArgsConstructor;
 @RequestMapping("/api/boss/stores")
 @PreAuthorize("hasRole('BOSS')")
 public class BossStoreController {
-	private final BossStoreFacade bossStoreFacade;
+    private final BossStoreFacade bossStoreFacade;
 
-	@PostMapping
-	public StoreCreateResponse createStore(@AuthenticationPrincipal CustomUserDetails userDetails,
-		@RequestBody @Valid StoreCreateRequest request) {
-		final Long userId = userDetails.getUserId();
-		return bossStoreFacade.createStore(userId, request);
-	}
+    @PostMapping
+    public StoreCreateResponse createStore(@AuthenticationPrincipal CustomUserDetails userDetails,
+                                           @RequestBody @Valid StoreCreateRequest request) {
+        final Long userId = userDetails.getUserId();
+        return bossStoreFacade.createStore(userId, request);
+    }
 
-	@PostMapping("/validations/business-number")
-	public void validateBusinessNumber(@RequestBody @Valid BusinessNumberRequest request) {
-		bossStoreFacade.validateBusinessNumber(request.businessNumber());
-	}
+    @PostMapping("/validations/business-number")
+    public void validateBusinessNumber(@RequestBody @Valid BusinessNumberRequest request) {
+        bossStoreFacade.validateBusinessNumber(request.businessNumber());
+    }
 }

--- a/app/src/main/java/com/mangoboss/app/api/controller/store/boss/BossStoreController.java
+++ b/app/src/main/java/com/mangoboss/app/api/controller/store/boss/BossStoreController.java
@@ -1,0 +1,37 @@
+package com.mangoboss.app.api.controller.store.boss;
+
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.mangoboss.app.api.facade.store.boss.BossStoreFacade;
+import com.mangoboss.app.common.exception.CustomUserDetails;
+import com.mangoboss.app.dto.store.request.BusinessNumberRequest;
+import com.mangoboss.app.dto.store.request.StoreCreateRequest;
+import com.mangoboss.app.dto.store.response.StoreCreateResponse;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/boss/stores")
+@PreAuthorize("hasRole('BOSS')")
+public class BossStoreController {
+	private final BossStoreFacade bossStoreFacade;
+
+	@PostMapping
+	public StoreCreateResponse createStore(@AuthenticationPrincipal CustomUserDetails userDetails,
+		@RequestBody @Valid StoreCreateRequest request) {
+		final Long userId = userDetails.getUserId();
+		return bossStoreFacade.createStore(userId, request);
+	}
+
+	@PostMapping("/validations/business-number")
+	public void validateBusinessNumber(@RequestBody @Valid BusinessNumberRequest request) {
+		bossStoreFacade.validateBusinessNumber(request.businessNumber());
+	}
+}

--- a/app/src/main/java/com/mangoboss/app/api/controller/user/UserController.java
+++ b/app/src/main/java/com/mangoboss/app/api/controller/user/UserController.java
@@ -10,7 +10,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.mangoboss.app.api.facade.user.UserFacade;
 import com.mangoboss.app.common.exception.CustomUserDetails;
-import com.mangoboss.app.dto.UserInfoResponse;
+import com.mangoboss.app.dto.user.response.UserInfoResponse;
 import com.mangoboss.app.dto.auth.requeset.SignUpRequest;
 
 import jakarta.validation.Valid;
@@ -30,8 +30,8 @@ public class UserController {
 
 	@PreAuthorize("hasRole('UNASSIGNED')")
 	@PostMapping("/sign-up")
-	public void signUp(@RequestBody @Valid SignUpRequest request,
-		@AuthenticationPrincipal CustomUserDetails userDetails) {
+	public void signUp(@AuthenticationPrincipal CustomUserDetails userDetails,
+		@RequestBody @Valid SignUpRequest request) {
 		final Long userId = userDetails.getUserId();
 		userFacade.signUp(userId, request);
 	}

--- a/app/src/main/java/com/mangoboss/app/api/facade/auth/AuthFacade.java
+++ b/app/src/main/java/com/mangoboss/app/api/facade/auth/AuthFacade.java
@@ -1,11 +1,10 @@
 package com.mangoboss.app.api.facade.auth;
 
 import com.mangoboss.app.domain.service.auth.AuthService;
-import com.mangoboss.app.dto.auth.requeset.SignUpRequest;
 import com.mangoboss.app.dto.auth.response.JwtResponse;
 import org.springframework.stereotype.Service;
 
-import com.mangoboss.app.dto.KakaoUserInfo;
+import com.mangoboss.app.dto.user.KakaoUserInfo;
 import com.mangoboss.app.dto.auth.requeset.RefreshTokenRequest;
 import com.mangoboss.app.domain.service.user.UserService;
 import com.mangoboss.app.dto.auth.requeset.LoginRequest;

--- a/app/src/main/java/com/mangoboss/app/api/facade/store/BossStoreFacade.java
+++ b/app/src/main/java/com/mangoboss/app/api/facade/store/BossStoreFacade.java
@@ -1,4 +1,4 @@
-package com.mangoboss.app.api.facade.store.boss;
+package com.mangoboss.app.api.facade.store;
 
 import org.springframework.stereotype.Service;
 

--- a/app/src/main/java/com/mangoboss/app/api/facade/store/boss/BossStoreFacade.java
+++ b/app/src/main/java/com/mangoboss/app/api/facade/store/boss/BossStoreFacade.java
@@ -1,0 +1,32 @@
+package com.mangoboss.app.api.facade.store.boss;
+
+import org.springframework.stereotype.Service;
+
+import com.mangoboss.app.domain.service.store.StoreService;
+import com.mangoboss.app.domain.service.user.UserService;
+import com.mangoboss.app.dto.store.request.StoreCreateRequest;
+import com.mangoboss.app.dto.store.response.StoreCreateResponse;
+import com.mangoboss.storage.store.StoreEntity;
+import com.mangoboss.storage.user.UserEntity;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class BossStoreFacade {
+	private final StoreService storeService;
+	private final UserService userService;
+
+	public StoreCreateResponse createStore(final Long userId, final StoreCreateRequest request) {
+		final UserEntity boss = userService.getUserById(userId);
+		storeService.validateBusinessNumber(request.businessNumber());
+		final StoreEntity saved = storeService.createStore(request, boss);
+		return StoreCreateResponse.fromEntity(saved);
+	}
+
+	public void validateBusinessNumber(final String businessNumber) {
+		storeService.validateBusinessNumber(businessNumber);
+	}
+}

--- a/app/src/main/java/com/mangoboss/app/api/facade/user/UserFacade.java
+++ b/app/src/main/java/com/mangoboss/app/api/facade/user/UserFacade.java
@@ -5,7 +5,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.mangoboss.app.common.exception.CustomUserDetails;
 import com.mangoboss.app.domain.service.user.UserService;
-import com.mangoboss.app.dto.UserInfoResponse;
+import com.mangoboss.app.dto.user.response.UserInfoResponse;
 import com.mangoboss.app.dto.auth.requeset.SignUpRequest;
 import com.mangoboss.storage.user.UserEntity;
 

--- a/app/src/main/java/com/mangoboss/app/common/exception/CustomErrorInfo.java
+++ b/app/src/main/java/com/mangoboss/app/common/exception/CustomErrorInfo.java
@@ -13,6 +13,7 @@ public enum CustomErrorInfo {
     URL_INPUT_ERROR(400, "URL 입력 오류입니다.", 400005),
     ILLEGAL_ARGUMENT_TOKEN(400, "토큰 형식이 잘못되었습니다.", 400006),
     KAKAO_USER_INFO_INCOMPLETE(400, "카카오에서 받아오는 정보 중 일부가 누락되었습니다.", 400007),
+    INVALID_BUSINESS_NUMBER(400, "유효하지 않은 사업자등록번호입니다.", 400008),
 
     // 401 Unauthorized
     LOGIN_NEEDED(401, "로그인이 필요합니다.", 401001),
@@ -31,9 +32,11 @@ public enum CustomErrorInfo {
     METHOD_NOT_ALLOWED(405, "HTTP 메서드가 잘못되었습니다.", 405001),
 
     // 409 CONFLICT
-    ALREADY_SIGNED_UP(409, "이미 가입된 사용자입니다.", 409001);
+	ALREADY_SIGNED_UP(409, "이미 가입된 사용자입니다.", 409001),
+    DUPLICATE_BUSINESS_NUMBER(409, "이미 망고보스에 등록된 사업자등록번호입니다.", 409002),
 
     // 500 INTERNAL_SERVER_ERROR
+    BUSINESS_API_FAILED(500, "사업자 진위 확인에 실패했습니다.", 500001);
 
     private final int statusCode;
     private final String message;

--- a/app/src/main/java/com/mangoboss/app/common/exception/CustomErrorInfo.java
+++ b/app/src/main/java/com/mangoboss/app/common/exception/CustomErrorInfo.java
@@ -27,12 +27,13 @@ public enum CustomErrorInfo {
     // 404 Not Found
     USER_NOT_FOUND(404, "사용자를 찾을 수 없습니다.", 404001),
     KAKAO_USER_INFO_NOT_FOUND(404, "카카오 사용자 정보 없음", 404002),
+    INVITE_CODE_NOT_FOUND(404, "초대코드가 잘못되었습니다.", 404003),
 
     // 405 Method Not Allowed
     METHOD_NOT_ALLOWED(405, "HTTP 메서드가 잘못되었습니다.", 405001),
 
     // 409 CONFLICT
-	ALREADY_SIGNED_UP(409, "이미 가입된 사용자입니다.", 409001),
+    ALREADY_SIGNED_UP(409, "이미 가입된 사용자입니다.", 409001),
     DUPLICATE_BUSINESS_NUMBER(409, "이미 망고보스에 등록된 사업자등록번호입니다.", 409002),
 
     // 500 INTERNAL_SERVER_ERROR

--- a/app/src/main/java/com/mangoboss/app/common/security/KakaoSocialLogin.java
+++ b/app/src/main/java/com/mangoboss/app/common/security/KakaoSocialLogin.java
@@ -18,7 +18,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.mangoboss.app.common.exception.CustomErrorInfo;
 import com.mangoboss.app.common.exception.CustomException;
-import com.mangoboss.app.dto.KakaoUserInfo;
+import com.mangoboss.app.dto.user.KakaoUserInfo;
 import com.mangoboss.app.dto.auth.requeset.LoginRequest;
 
 import lombok.extern.slf4j.Slf4j;

--- a/app/src/main/java/com/mangoboss/app/domain/repository/StoreRepository.java
+++ b/app/src/main/java/com/mangoboss/app/domain/repository/StoreRepository.java
@@ -1,11 +1,15 @@
 package com.mangoboss.app.domain.repository;
 
 import com.mangoboss.storage.store.StoreEntity;
-import java.util.Optional;
 
 public interface StoreRepository {
-	boolean existsByBusinessNumber(String businessNumber);
-	boolean existsByInviteCode(String inviteCode);
-	boolean existsByAttendanceQrCode(String qrCode);
-	StoreEntity save(StoreEntity storeEntity);
+    boolean existsByBusinessNumber(String businessNumber);
+
+    boolean existsByInviteCode(String inviteCode);
+
+    boolean existsByAttendanceQrCode(String qrCode);
+
+    StoreEntity save(StoreEntity storeEntity);
+
+    StoreEntity getByInviteCode(String inviteCode);
 }

--- a/app/src/main/java/com/mangoboss/app/domain/repository/StoreRepository.java
+++ b/app/src/main/java/com/mangoboss/app/domain/repository/StoreRepository.java
@@ -1,0 +1,11 @@
+package com.mangoboss.app.domain.repository;
+
+import com.mangoboss.storage.store.StoreEntity;
+import java.util.Optional;
+
+public interface StoreRepository {
+	boolean existsByBusinessNumber(String businessNumber);
+	boolean existsByInviteCode(String inviteCode);
+	boolean existsByAttendanceQrCode(String qrCode);
+	StoreEntity save(StoreEntity storeEntity);
+}

--- a/app/src/main/java/com/mangoboss/app/domain/service/auth/AuthService.java
+++ b/app/src/main/java/com/mangoboss/app/domain/service/auth/AuthService.java
@@ -4,7 +4,7 @@ import com.mangoboss.app.common.exception.CustomErrorInfo;
 import com.mangoboss.app.common.exception.CustomException;
 import com.mangoboss.app.common.security.KakaoSocialLogin;
 import com.mangoboss.app.common.util.JwtUtil;
-import com.mangoboss.app.dto.KakaoUserInfo;
+import com.mangoboss.app.dto.user.KakaoUserInfo;
 import com.mangoboss.app.dto.auth.requeset.LoginRequest;
 import com.mangoboss.app.dto.auth.response.JwtResponse;
 import com.mangoboss.storage.user.UserEntity;

--- a/app/src/main/java/com/mangoboss/app/domain/service/store/StoreService.java
+++ b/app/src/main/java/com/mangoboss/app/domain/service/store/StoreService.java
@@ -1,0 +1,65 @@
+package com.mangoboss.app.domain.service.store;
+
+import org.apache.commons.lang3.RandomStringUtils;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.mangoboss.app.ExternalBusinessApiClient;
+import com.mangoboss.app.common.exception.CustomErrorInfo;
+import com.mangoboss.app.common.exception.CustomException;
+import com.mangoboss.app.domain.repository.StoreRepository;
+import com.mangoboss.app.dto.store.request.StoreCreateRequest;
+import com.mangoboss.storage.store.StoreEntity;
+import com.mangoboss.storage.user.UserEntity;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class StoreService {
+	private final StoreRepository storeRepository;
+	private final ExternalBusinessApiClient externalBusinessApiClient;
+
+	@Transactional(readOnly = true)
+	public boolean isDuplicatedBusinessNumber(final String businessNumber) {
+		return storeRepository.existsByBusinessNumber(businessNumber);
+	}
+
+	@Transactional(readOnly = true)
+	public void validateBusinessNumber(final String businessNumber) {
+		if (!externalBusinessApiClient.checkBusinessNumberValid(businessNumber)) {
+			throw new CustomException(CustomErrorInfo.INVALID_BUSINESS_NUMBER);
+		}
+
+		if (isDuplicatedBusinessNumber(businessNumber)) {
+			throw new CustomException(CustomErrorInfo.DUPLICATE_BUSINESS_NUMBER);
+		}
+	}
+
+	public StoreEntity createStore(final StoreCreateRequest request, final UserEntity boss) {
+		validateBusinessNumber(request.businessNumber());
+		final String inviteCode = generateInviteCode();
+		final String attendanceQrCode = generateQrCode();
+		final StoreEntity store = request.toEntity(boss, inviteCode, attendanceQrCode);
+		return storeRepository.save(store);
+	}
+
+	private String generateInviteCode() {
+		// 중복 방지를 위해 초대 코드를 생성하고 DB에 존재하는지 검사
+		String code;
+		do {
+			code = RandomStringUtils.randomAlphanumeric(6).toUpperCase(); // 영문+숫자 6자리
+		} while (storeRepository.existsByInviteCode(code));
+		return code;
+	}
+
+	private String generateQrCode() {
+		// 중복 방지를 위해 QR 코드를 생성하고 DB에 존재하는지 검사
+		String code;
+		do {
+			code = RandomStringUtils.randomAlphanumeric(12).toUpperCase();  // 영문+숫자 12자리
+		} while (storeRepository.existsByAttendanceQrCode(code));
+		return code;
+	}
+}

--- a/app/src/main/java/com/mangoboss/app/domain/service/store/StoreService.java
+++ b/app/src/main/java/com/mangoboss/app/domain/service/store/StoreService.java
@@ -1,5 +1,7 @@
 package com.mangoboss.app.domain.service.store;
 
+import java.security.SecureRandom;
+
 import org.apache.commons.lang3.RandomStringUtils;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -18,48 +20,64 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 @Transactional
 public class StoreService {
-	private final StoreRepository storeRepository;
-	private final ExternalBusinessApiClient externalBusinessApiClient;
+    private static final String CHAR_POOL = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+    private static final int INVITE_CODE_LENGTH = 6;
+    private static final int QR_CODE_LENGTH = 12;
 
-	@Transactional(readOnly = true)
-	public boolean isDuplicatedBusinessNumber(final String businessNumber) {
-		return storeRepository.existsByBusinessNumber(businessNumber);
-	}
+    private final SecureRandom random = new SecureRandom();
+    private final StoreRepository storeRepository;
+    private final ExternalBusinessApiClient externalBusinessApiClient;
 
-	@Transactional(readOnly = true)
-	public void validateBusinessNumber(final String businessNumber) {
-		if (!externalBusinessApiClient.checkBusinessNumberValid(businessNumber)) {
-			throw new CustomException(CustomErrorInfo.INVALID_BUSINESS_NUMBER);
-		}
+    @Transactional(readOnly = true)
+    public boolean isDuplicatedBusinessNumber(final String businessNumber) {
+        return storeRepository.existsByBusinessNumber(businessNumber);
+    }
 
-		if (isDuplicatedBusinessNumber(businessNumber)) {
-			throw new CustomException(CustomErrorInfo.DUPLICATE_BUSINESS_NUMBER);
-		}
-	}
+    @Transactional(readOnly = true)
+    public void validateBusinessNumber(final String businessNumber) {
+        if (!externalBusinessApiClient.checkBusinessNumberValid(businessNumber)) {
+            throw new CustomException(CustomErrorInfo.INVALID_BUSINESS_NUMBER);
+        }
 
-	public StoreEntity createStore(final StoreCreateRequest request, final UserEntity boss) {
-		validateBusinessNumber(request.businessNumber());
-		final String inviteCode = generateInviteCode();
-		final String attendanceQrCode = generateQrCode();
-		final StoreEntity store = request.toEntity(boss, inviteCode, attendanceQrCode);
-		return storeRepository.save(store);
-	}
+        if (isDuplicatedBusinessNumber(businessNumber)) {
+            throw new CustomException(CustomErrorInfo.DUPLICATE_BUSINESS_NUMBER);
+        }
+    }
 
-	private String generateInviteCode() {
-		// 중복 방지를 위해 초대 코드를 생성하고 DB에 존재하는지 검사
-		String code;
-		do {
-			code = RandomStringUtils.randomAlphanumeric(6).toUpperCase(); // 영문+숫자 6자리
-		} while (storeRepository.existsByInviteCode(code));
-		return code;
-	}
+    public StoreEntity getStoreByInviteCode(final String inviteCode) {
+        return storeRepository.getByInviteCode(inviteCode);
+    }
 
-	private String generateQrCode() {
-		// 중복 방지를 위해 QR 코드를 생성하고 DB에 존재하는지 검사
-		String code;
-		do {
-			code = RandomStringUtils.randomAlphanumeric(12).toUpperCase();  // 영문+숫자 12자리
-		} while (storeRepository.existsByAttendanceQrCode(code));
-		return code;
-	}
+    public StoreEntity createStore(final StoreCreateRequest request, final UserEntity boss) {
+        validateBusinessNumber(request.businessNumber());
+        final String inviteCode = generateInviteCode();
+        final String attendanceQrCode = generateQrCode();
+        final StoreEntity store = request.toEntity(boss, inviteCode, attendanceQrCode);
+        return storeRepository.save(store);
+    }
+
+    private String generateInviteCode() {
+        String code;
+        do {
+            code = randomString(INVITE_CODE_LENGTH);
+        } while (storeRepository.existsByInviteCode(code));
+        return code;
+    }
+
+    private String generateQrCode() {
+        // 중복 방지를 위해 QR 코드를 생성하고 DB에 존재하는지 검사
+        String code;
+        do {
+            code = randomString(QR_CODE_LENGTH);
+        } while (storeRepository.existsByAttendanceQrCode(code));
+        return code;
+    }
+
+    private String randomString(final int length) {
+        StringBuilder sb = new StringBuilder(length);
+        for (int i = 0; i < length; i++) {
+            sb.append(CHAR_POOL.charAt(random.nextInt(CHAR_POOL.length())));
+        }
+        return sb.toString();
+    }
 }

--- a/app/src/main/java/com/mangoboss/app/domain/service/user/UserService.java
+++ b/app/src/main/java/com/mangoboss/app/domain/service/user/UserService.java
@@ -6,7 +6,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.mangoboss.app.common.exception.CustomErrorInfo;
 import com.mangoboss.app.common.exception.CustomException;
 import com.mangoboss.app.domain.repository.UserRepository;
-import com.mangoboss.app.dto.KakaoUserInfo;
+import com.mangoboss.app.dto.user.KakaoUserInfo;
 import com.mangoboss.storage.user.Role;
 import com.mangoboss.storage.user.UserEntity;
 

--- a/app/src/main/java/com/mangoboss/app/dto/store/request/BusinessNumberRequest.java
+++ b/app/src/main/java/com/mangoboss/app/dto/store/request/BusinessNumberRequest.java
@@ -1,0 +1,8 @@
+package com.mangoboss.app.dto.store.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record BusinessNumberRequest(
+	@NotBlank
+	String businessNumber
+) {}

--- a/app/src/main/java/com/mangoboss/app/dto/store/request/StoreCreateRequest.java
+++ b/app/src/main/java/com/mangoboss/app/dto/store/request/StoreCreateRequest.java
@@ -7,41 +7,50 @@ import com.mangoboss.storage.user.UserEntity;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
+import java.sql.Time;
+
 public record StoreCreateRequest(
-	@NotBlank
-	String name,
+        @NotBlank
+        String name,
 
-	@NotBlank
-	String businessNumber,
+        @NotBlank
+        String address,
 
-	@NotNull
-	StoreType storeType,
+        @NotBlank
+        String businessNumber,
 
-	@NotBlank
-	String address,
+        @NotNull
+        StoreType storeType,
 
-	@NotNull
-	Gps gps
+        String chatLink,
+
+        Time workingTimeUnit,
+
+        @NotNull
+        Gps gps
 ) {
-	public record Gps(
-		@NotNull
-		Double longitude,
+    public record Gps(
+            @NotNull
+            Double longitude,
 
-		@NotNull
-		Double latitude
-	) {}
+            @NotNull
+            Double latitude
+    ) {
+    }
 
-	public StoreEntity toEntity(final UserEntity boss, final String inviteCode, final String qrCode) {
-		return StoreEntity.create(
-			boss,
-			this.name(),
-			this.address(),
-			this.storeType(),
-			this.businessNumber(),
-			inviteCode,
-			this.gps().latitude(),
-			this.gps().longitude(),
-			qrCode
-		);
-	}
+    public StoreEntity toEntity(final UserEntity boss, final String inviteCode, final String qrCode) {
+        return StoreEntity.create(
+                boss,
+                this.name(),
+                this.address(),
+                this.businessNumber,
+                this.storeType(),
+                inviteCode,
+                this.chatLink,
+                this.workingTimeUnit,
+                this.gps().latitude(),
+                this.gps().longitude(),
+                qrCode
+        );
+    }
 }

--- a/app/src/main/java/com/mangoboss/app/dto/store/request/StoreCreateRequest.java
+++ b/app/src/main/java/com/mangoboss/app/dto/store/request/StoreCreateRequest.java
@@ -1,0 +1,47 @@
+package com.mangoboss.app.dto.store.request;
+
+import com.mangoboss.storage.store.StoreEntity;
+import com.mangoboss.storage.store.StoreType;
+import com.mangoboss.storage.user.UserEntity;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record StoreCreateRequest(
+	@NotBlank
+	String name,
+
+	@NotBlank
+	String businessNumber,
+
+	@NotNull
+	StoreType storeType,
+
+	@NotBlank
+	String address,
+
+	@NotNull
+	Gps gps
+) {
+	public record Gps(
+		@NotNull
+		Double longitude,
+
+		@NotNull
+		Double latitude
+	) {}
+
+	public StoreEntity toEntity(final UserEntity boss, final String inviteCode, final String qrCode) {
+		return StoreEntity.create(
+			boss,
+			this.name(),
+			this.address(),
+			this.storeType(),
+			this.businessNumber(),
+			inviteCode,
+			this.gps().latitude(),
+			this.gps().longitude(),
+			qrCode
+		);
+	}
+}

--- a/app/src/main/java/com/mangoboss/app/dto/store/response/StoreCreateResponse.java
+++ b/app/src/main/java/com/mangoboss/app/dto/store/response/StoreCreateResponse.java
@@ -1,0 +1,16 @@
+package com.mangoboss.app.dto.store.response;
+
+import com.mangoboss.storage.store.StoreEntity;
+
+import lombok.Builder;
+
+@Builder
+public record StoreCreateResponse(
+	Long storeId
+) {
+	public static StoreCreateResponse fromEntity(final StoreEntity entity) {
+		return StoreCreateResponse.builder()
+			.storeId(entity.getId())
+			.build();
+	}
+}

--- a/app/src/main/java/com/mangoboss/app/dto/user/KakaoUserInfo.java
+++ b/app/src/main/java/com/mangoboss/app/dto/user/KakaoUserInfo.java
@@ -1,4 +1,4 @@
-package com.mangoboss.app.dto;
+package com.mangoboss.app.dto.user;
 
 import com.mangoboss.storage.user.Role;
 import com.mangoboss.storage.user.UserEntity;
@@ -28,16 +28,16 @@ public record KakaoUserInfo(
 				.build();
 	}
 
-	public UserEntity toEntity(final Role role){
-		return UserEntity.builder()
-				.kakaoId(kakaoId)
-				.phone(phone)
-				.name(name)
-				.email(email)
-				.birth(birth)
-				.profileImageUrl(profileImageUrl)
-				.role(role)
-				.build();
+	public UserEntity toEntity(final Role role) {
+		return UserEntity.create(
+			kakaoId,
+			name,
+			email,
+			phone,
+			birth,
+			profileImageUrl,
+			role
+		);
 	}
 
 	public void validate() {

--- a/app/src/main/java/com/mangoboss/app/dto/user/response/UserInfoResponse.java
+++ b/app/src/main/java/com/mangoboss/app/dto/user/response/UserInfoResponse.java
@@ -1,4 +1,4 @@
-package com.mangoboss.app.dto;
+package com.mangoboss.app.dto.user.response;
 
 import com.mangoboss.storage.user.UserEntity;
 

--- a/app/src/main/java/com/mangoboss/app/infra/persistence/StoreRepositoryImpl.java
+++ b/app/src/main/java/com/mangoboss/app/infra/persistence/StoreRepositoryImpl.java
@@ -1,5 +1,7 @@
 package com.mangoboss.app.infra.persistence;
 
+import com.mangoboss.app.common.exception.CustomErrorInfo;
+import com.mangoboss.app.common.exception.CustomException;
 import org.springframework.stereotype.Repository;
 
 import com.mangoboss.app.domain.repository.StoreRepository;
@@ -12,25 +14,32 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class StoreRepositoryImpl implements StoreRepository {
 
-	private final StoreJpaRepository storeJpaRepository;
+    private final StoreJpaRepository storeJpaRepository;
 
-	@Override
-	public boolean existsByBusinessNumber(final String businessNumber) {
-		return storeJpaRepository.existsByBusinessNumber(businessNumber);
-	}
+    @Override
+    public boolean existsByBusinessNumber(final String businessNumber) {
+        return storeJpaRepository.existsByBusinessNumber(businessNumber);
+    }
 
-	@Override
-	public boolean existsByInviteCode(final String inviteCode) {
-		return storeJpaRepository.existsByInviteCode(inviteCode);
-	}
+    @Override
+    public boolean existsByInviteCode(final String inviteCode) {
+        return storeJpaRepository.existsByInviteCode(inviteCode);
+    }
 
-	@Override
-	public boolean existsByAttendanceQrCode(final String qrCode) {
-		return storeJpaRepository.existsByAttendanceQrCode(qrCode);
-	}
+    @Override
+    public boolean existsByAttendanceQrCode(final String qrCode) {
+        return storeJpaRepository.existsByQrCode(qrCode);
+    }
 
-	@Override
-	public StoreEntity save(final StoreEntity storeEntity) {
-		return storeJpaRepository.save(storeEntity);
-	}
+    @Override
+    public StoreEntity save(final StoreEntity storeEntity) {
+        return storeJpaRepository.save(storeEntity);
+    }
+
+    @Override
+    public StoreEntity getByInviteCode(final String inviteCode) {
+        return storeJpaRepository.findByInviteCode(inviteCode)
+                .orElseThrow(() -> new CustomException(CustomErrorInfo.INVITE_CODE_NOT_FOUND));
+    }
+
 }

--- a/app/src/main/java/com/mangoboss/app/infra/persistence/StoreRepositoryImpl.java
+++ b/app/src/main/java/com/mangoboss/app/infra/persistence/StoreRepositoryImpl.java
@@ -1,0 +1,36 @@
+package com.mangoboss.app.infra.persistence;
+
+import org.springframework.stereotype.Repository;
+
+import com.mangoboss.app.domain.repository.StoreRepository;
+import com.mangoboss.storage.store.StoreEntity;
+import com.mangoboss.storage.store.StoreJpaRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class StoreRepositoryImpl implements StoreRepository {
+
+	private final StoreJpaRepository storeJpaRepository;
+
+	@Override
+	public boolean existsByBusinessNumber(final String businessNumber) {
+		return storeJpaRepository.existsByBusinessNumber(businessNumber);
+	}
+
+	@Override
+	public boolean existsByInviteCode(final String inviteCode) {
+		return storeJpaRepository.existsByInviteCode(inviteCode);
+	}
+
+	@Override
+	public boolean existsByAttendanceQrCode(final String qrCode) {
+		return storeJpaRepository.existsByAttendanceQrCode(qrCode);
+	}
+
+	@Override
+	public StoreEntity save(final StoreEntity storeEntity) {
+		return storeJpaRepository.save(storeEntity);
+	}
+}

--- a/app/src/main/resources/application-dev.yml
+++ b/app/src/main/resources/application-dev.yml
@@ -10,7 +10,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: create-drop
+      ddl-auto: create
 
   jwt:
     secret:
@@ -48,10 +48,3 @@ logging:
   level:
     org.hibernate.SQL: DEBUG
     org.hibernate.stat: DEBUG
-
-    com.zaxxer.hikari: TRACE
-    com.zaxxer.hikari.HikariConfig: DEBUG
-    org.springframework.jdbc.core.JdbcTemplate: DEBUG
-    org.springframework.jdbc.core.StatementCreatorUtils: TRACE
-
-

--- a/app/src/main/resources/application-dev.yml
+++ b/app/src/main/resources/application-dev.yml
@@ -41,7 +41,9 @@ spring:
             token-uri: https://kauth.kakao.com/oauth/token
             user-info-uri: https://kapi.kakao.com/v2/user/me
             user-name-attribute: id
-
+external:
+  business-api:
+    key: ${BUSINESS_API_KEY}
 logging:
   level:
     org.hibernate.SQL: DEBUG

--- a/app/src/main/resources/application-dev.yml
+++ b/app/src/main/resources/application-dev.yml
@@ -41,10 +41,3 @@ spring:
             token-uri: https://kauth.kakao.com/oauth/token
             user-info-uri: https://kapi.kakao.com/v2/user/me
             user-name-attribute: id
-external:
-  business-api:
-    key: ${BUSINESS_API_KEY}
-logging:
-  level:
-    org.hibernate.SQL: DEBUG
-    org.hibernate.stat: DEBUG

--- a/app/src/main/resources/application-test.yml
+++ b/app/src/main/resources/application-test.yml
@@ -15,12 +15,12 @@ spring:
       ddl-auto: create
   jwt:
     secret:
-      access-secret-key: ${JWT_SECRET}
-      refresh-secret-key: ${JWT_SECRET}
+      access-secret-key: ${JWT_SECRET:jwtsecretkeydefaultfortestasdasdasdsadsadsa}
+      refresh-secret-key: ${JWT_SECRET:jwtsecretkeydefaultfortestasdadsadassaasds}
     token:
       access-expiration-time: ${JWT_ACCESS_EXPIRATION:3600000}
       refresh-expiration-time: ${JWT_REFRESH_EXPIRATION:604800000}
-      issuer: ${JWT_ISSUER:test-issuer}
+      issuer: ${JWT_ISSUER:jwtissuerkeydefaultfortest}
 
 
   security:
@@ -28,9 +28,9 @@ spring:
       client:
         registration:
           kakao:
-            client-id: ${KAKAO_CLIENT_ID}
+            client-id: ${KAKAO_CLIENT_ID:kakaoclientiddefaultfortest}
             authorization-grant-type: authorization_code
-            redirect-uri: ${KAKAO_REDIRECT_URI}
+            redirect-uri: ${KAKAO_REDIRECT_URI:http://localhost:8080/oauth2/callback/kakao}
             scope:
               - profile_nickname
               - account_email
@@ -43,13 +43,3 @@ spring:
             token-uri: https://kauth.kakao.com/oauth/token
             user-info-uri: https://kapi.kakao.com/v2/user/me
             user-name-attribute: id
-
-logging:
-  level:
-    org.hibernate.SQL: DEBUG
-    org.hibernate.stat: DEBUG
-
-    com.zaxxer.hikari: TRACE
-    com.zaxxer.hikari.HikariConfig: DEBUG
-    org.springframework.jdbc.core.JdbcTemplate: DEBUG
-    org.springframework.jdbc.core.StatementCreatorUtils: TRACE

--- a/app/src/main/resources/application.yml
+++ b/app/src/main/resources/application.yml
@@ -10,9 +10,18 @@ spring:
       prod: mysql-prod
 
   config:
-    import: "application-dev.yml"
+    import: "application-dev.yml,application-test.yml"
 
 server:
   port: 8080
 
 test_env: ${TEST_ENV_VAR:test_is_fail}
+
+external:
+  business-api:
+    key: ${BUSINESS_API_KEY:bussinessapikeytest}
+
+logging:
+  level:
+    org.hibernate.SQL: DEBUG
+    org.hibernate.stat: DEBUG

--- a/storage/src/main/java/com/mangoboss/storage/store/AttendanceMethod.java
+++ b/storage/src/main/java/com/mangoboss/storage/store/AttendanceMethod.java
@@ -1,0 +1,7 @@
+package com.mangoboss.storage.store;
+
+public enum AttendanceMethod {
+	GPS,
+	QR,
+	BOTH,
+}

--- a/storage/src/main/java/com/mangoboss/storage/store/StoreEntity.java
+++ b/storage/src/main/java/com/mangoboss/storage/store/StoreEntity.java
@@ -1,0 +1,145 @@
+package com.mangoboss.storage.store;
+
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+import com.mangoboss.storage.BaseTimeEntity;
+import com.mangoboss.storage.user.UserEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "\"store\"")
+public class StoreEntity extends BaseTimeEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "store_id")
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "boss_id", nullable = false)
+	private UserEntity boss;
+
+	@Column(nullable = false)
+	private String name;
+
+	@Column(nullable = false)
+	private String address;
+
+	@Column(nullable = false)
+	private String businessNumber;
+
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false)
+	private StoreType storeType;
+
+	private LocalDateTime remittanceDate;
+
+	private LocalTime payUnitMinutes;
+
+	private Long remittanceAccount;
+
+	private String inviteCode;
+
+	private String chatLink;
+
+	private LocalTime overtimeLimit;
+
+	@Column(nullable = false)
+	private Integer gpsRangeMeters;
+
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false)
+	private AttendanceMethod attendanceMethod; // ex) GPS, QR, BOTH
+
+	@Column(nullable = false)
+	private Double latitude;
+
+	@Column(nullable = false)
+	private Double longitude;
+
+	@Column(nullable = false)
+	private String attendanceQrCode;
+
+	@Builder
+	public StoreEntity(
+		final Long id,
+		final UserEntity boss,
+		final String name,
+		final String address,
+		final String businessNumber,
+		final StoreType storeType,
+		final LocalDateTime remittanceDate,
+		final LocalTime payUnitMinutes,
+		final Long remittanceAccount,
+		final String inviteCode,
+		final String chatLink,
+		final LocalTime overtimeLimit,
+		final Integer gpsRangeMeters,
+		final AttendanceMethod attendanceMethod,
+		final Double latitude,
+		final Double longitude,
+		final String attendanceQrCode
+	) {
+		this.id = id;
+		this.boss = boss;
+		this.name = name;
+		this.address = address;
+		this.businessNumber = businessNumber;
+		this.storeType = storeType;
+		this.remittanceDate = remittanceDate;
+		this.payUnitMinutes = payUnitMinutes;
+		this.remittanceAccount = remittanceAccount;
+		this.inviteCode = inviteCode;
+		this.chatLink = chatLink;
+		this.overtimeLimit = overtimeLimit;
+		this.gpsRangeMeters = gpsRangeMeters;
+		this.attendanceMethod = attendanceMethod;
+		this.latitude = latitude;
+		this.longitude = longitude;
+		this.attendanceQrCode = attendanceQrCode;
+	}
+
+	public static StoreEntity create(
+		final UserEntity boss,
+		final String name,
+		final String address,
+		final StoreType storeType,
+		final String businessNumber,
+		final String inviteCode,
+		final Double latitude,
+		final Double longitude,
+		final String attendanceQrCode
+	) {
+		return StoreEntity.builder()
+			.boss(boss)
+			.name(name)
+			.address(address)
+			.storeType(storeType)
+			.businessNumber(businessNumber)
+			.inviteCode(inviteCode)
+			.latitude(latitude)
+			.longitude(longitude)
+			.gpsRangeMeters(100) // 기본 - 100m
+			.attendanceMethod(AttendanceMethod.GPS) //  기본 - GPS
+			.attendanceQrCode(attendanceQrCode)
+			.build();
+	}
+}

--- a/storage/src/main/java/com/mangoboss/storage/store/StoreEntity.java
+++ b/storage/src/main/java/com/mangoboss/storage/store/StoreEntity.java
@@ -1,145 +1,106 @@
 package com.mangoboss.storage.store;
 
-import java.time.LocalDateTime;
-import java.time.LocalTime;
+import com.mangoboss.storage.user.UserEntity;
+import jakarta.persistence.*;
+
+import java.sql.Time;
 
 import com.mangoboss.storage.BaseTimeEntity;
-import com.mangoboss.storage.user.UserEntity;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
-@Table(name = "\"store\"")
+@Table(name = "store")
 public class StoreEntity extends BaseTimeEntity {
 
-	@Id
-	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	@Column(name = "store_id")
-	private Long id;
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "store_id")
+    private Long id;
 
-	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "boss_id", nullable = false)
-	private UserEntity boss;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "boss_id")
+    private UserEntity boss;
 
-	@Column(nullable = false)
-	private String name;
+    @Column(nullable = false)
+    private String name;
 
-	@Column(nullable = false)
-	private String address;
+    @Column(nullable = false)
+    private String address;
 
-	@Column(nullable = false)
-	private String businessNumber;
+    @Column(nullable = false)
+    private String businessNumber;
 
-	@Enumerated(EnumType.STRING)
-	@Column(nullable = false)
-	private StoreType storeType;
+    @Column(nullable = false)
+    private StoreType storeType;
 
-	private LocalDateTime remittanceDate;
+    @Column(nullable = false, unique = true)
+    private String inviteCode;
 
-	private LocalTime payUnitMinutes;
+    private String chatLink;
 
-	private Long remittanceAccount;
+    private Time workingTimeUnit;
 
-	private String inviteCode;
+    //여기서부터 출퇴근 인증방식
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private AttendanceMethod attendanceMethod;
 
-	private String chatLink;
+    private Integer gpsRangeMeters;
 
-	private LocalTime overtimeLimit;
+    @Column(nullable = false)
+    private Double gpsLatitude;
 
-	@Column(nullable = false)
-	private Integer gpsRangeMeters;
+    @Column(nullable = false)
+    private Double gpsLongitude;
 
-	@Enumerated(EnumType.STRING)
-	@Column(nullable = false)
-	private AttendanceMethod attendanceMethod; // ex) GPS, QR, BOTH
+    @Column(nullable = false, unique = true)
+    private String qrCode;
 
-	@Column(nullable = false)
-	private Double latitude;
+    @Builder
+    private StoreEntity(final UserEntity boss, final String name, final String address, final String businessNumber,
+                        final StoreType storeType, final String inviteCode, final String chatLink, final Time workingTimeUnit,
+                        final AttendanceMethod attendanceMethod, final Integer gpsRangeMeters,
+                        final Double gpsLatitude, final Double gpsLongitude, final String qrCode) {
+        this.boss = boss;
+        this.name = name;
+        this.address = address;
+        this.businessNumber = businessNumber;
+        this.storeType = storeType;
+        this.inviteCode = inviteCode;
+        this.chatLink = chatLink;
+        this.workingTimeUnit = workingTimeUnit;
+        this.attendanceMethod = attendanceMethod;
+        this.gpsRangeMeters = gpsRangeMeters;
+        this.gpsLatitude = gpsLatitude;
+        this.gpsLongitude = gpsLongitude;
+        this.qrCode = qrCode;
+    }
 
-	@Column(nullable = false)
-	private Double longitude;
-
-	@Column(nullable = false)
-	private String attendanceQrCode;
-
-	@Builder
-	public StoreEntity(
-		final Long id,
-		final UserEntity boss,
-		final String name,
-		final String address,
-		final String businessNumber,
-		final StoreType storeType,
-		final LocalDateTime remittanceDate,
-		final LocalTime payUnitMinutes,
-		final Long remittanceAccount,
-		final String inviteCode,
-		final String chatLink,
-		final LocalTime overtimeLimit,
-		final Integer gpsRangeMeters,
-		final AttendanceMethod attendanceMethod,
-		final Double latitude,
-		final Double longitude,
-		final String attendanceQrCode
-	) {
-		this.id = id;
-		this.boss = boss;
-		this.name = name;
-		this.address = address;
-		this.businessNumber = businessNumber;
-		this.storeType = storeType;
-		this.remittanceDate = remittanceDate;
-		this.payUnitMinutes = payUnitMinutes;
-		this.remittanceAccount = remittanceAccount;
-		this.inviteCode = inviteCode;
-		this.chatLink = chatLink;
-		this.overtimeLimit = overtimeLimit;
-		this.gpsRangeMeters = gpsRangeMeters;
-		this.attendanceMethod = attendanceMethod;
-		this.latitude = latitude;
-		this.longitude = longitude;
-		this.attendanceQrCode = attendanceQrCode;
-	}
-
-	public static StoreEntity create(
-		final UserEntity boss,
-		final String name,
-		final String address,
-		final StoreType storeType,
-		final String businessNumber,
-		final String inviteCode,
-		final Double latitude,
-		final Double longitude,
-		final String attendanceQrCode
-	) {
-		return StoreEntity.builder()
-			.boss(boss)
-			.name(name)
-			.address(address)
-			.storeType(storeType)
-			.businessNumber(businessNumber)
-			.inviteCode(inviteCode)
-			.latitude(latitude)
-			.longitude(longitude)
-			.gpsRangeMeters(100) // 기본 - 100m
-			.attendanceMethod(AttendanceMethod.GPS) //  기본 - GPS
-			.attendanceQrCode(attendanceQrCode)
-			.build();
-	}
+    public static StoreEntity create(final UserEntity boss, final String name, final String address,
+            final String businessNumber, final StoreType storeType, final String inviteCode,
+            final String chatLink, final Time workingTimeUnit, final Double gpsLatitude, final Double gpsLongitude, final String qrCode
+    ) {
+        return StoreEntity.builder()
+                .boss(boss)
+                .name(name)
+                .address(address)
+                .businessNumber(businessNumber)
+                .storeType(storeType)
+                .inviteCode(inviteCode)
+                .chatLink(chatLink)
+                .workingTimeUnit(workingTimeUnit)
+                .attendanceMethod(AttendanceMethod.QR)
+                .gpsRangeMeters(50)
+                .gpsLatitude(gpsLatitude)
+                .gpsLongitude(gpsLongitude)
+                .qrCode(qrCode)
+                .build();
+    }
 }

--- a/storage/src/main/java/com/mangoboss/storage/store/StoreJpaRepository.java
+++ b/storage/src/main/java/com/mangoboss/storage/store/StoreJpaRepository.java
@@ -1,0 +1,9 @@
+package com.mangoboss.storage.store;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface StoreJpaRepository extends JpaRepository<StoreEntity, Long> {
+	boolean existsByBusinessNumber(String businessNumber);
+	boolean existsByInviteCode(String inviteCode);
+	boolean existsByAttendanceQrCode(String qrCode);
+}

--- a/storage/src/main/java/com/mangoboss/storage/store/StoreJpaRepository.java
+++ b/storage/src/main/java/com/mangoboss/storage/store/StoreJpaRepository.java
@@ -1,9 +1,11 @@
 package com.mangoboss.storage.store;
 
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface StoreJpaRepository extends JpaRepository<StoreEntity, Long> {
 	boolean existsByBusinessNumber(String businessNumber);
 	boolean existsByInviteCode(String inviteCode);
-	boolean existsByAttendanceQrCode(String qrCode);
+	boolean existsByQrCode(String qrCode);
+    Optional<StoreEntity> findByInviteCode(String inviteCode);
 }

--- a/storage/src/main/java/com/mangoboss/storage/store/StoreType.java
+++ b/storage/src/main/java/com/mangoboss/storage/store/StoreType.java
@@ -1,0 +1,10 @@
+package com.mangoboss.storage.store;
+
+import lombok.Getter;
+
+@Getter
+public enum StoreType {
+	CAFE,
+	RESTAURANT,
+	CONVENIENCE_STORE,
+}

--- a/storage/src/main/java/com/mangoboss/storage/user/UserEntity.java
+++ b/storage/src/main/java/com/mangoboss/storage/user/UserEntity.java
@@ -64,7 +64,7 @@ public class UserEntity extends BaseTimeEntity {
 	}
 
 	public static UserEntity create(final Long kakaoId, final String name, final String email, final String phone,
-				final LocalDate birth, final String profileImageUrl, final Role role, final LocalDateTime createdAt) {
+				final LocalDate birth, final String profileImageUrl, final Role role) {
 		return UserEntity.builder()
 			.kakaoId(kakaoId)
 			.name(name)

--- a/storage/src/main/java/com/mangoboss/storage/user/UserJpaRepository.java
+++ b/storage/src/main/java/com/mangoboss/storage/user/UserJpaRepository.java
@@ -1,12 +1,9 @@
 package com.mangoboss.storage.user;
 
-import com.mangoboss.storage.user.UserEntity;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
 
-@Repository
 public interface UserJpaRepository extends JpaRepository<UserEntity, Long> {
 	Optional<UserEntity> findByKakaoId(final Long kakaoId);
 }


### PR DESCRIPTION
## #️⃣ 연관 이슈
> #6

### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 💻 작업 내용
> 사장은 매장 등록을 위해 가게 상호명, 업종, 사업자 번호 등을 입력하고 수정할 수 있다. (2-1)
> 사장은 알바생을 초대할 수 있는 매장별 초대코드를 발급받을 수 있다. (2-5)
- [x] 매장 등록 API 개발 (2-1-2)
- [x] 사업자 번호를 인증하는 API 개발 (2-1-3) 
- [x] 초대 링크/매장 초대 코드 생성 API 개발 (2-5-2) 
- [x] 공공데이터포털 - 국세청_사업자등록정보 진위확인 및 상태조회 서비스 API 연동

### 테스트 결과 or 스크린샷 (선택)
> 작업한 부분을 캡처해 보여주면 이해하기 쉬워요

## 💬 리뷰 요구사항 (선택)

