### PR TITLE
[#44] 사장 제출 서류 설정 조회 및 저장 기능 개발 

### DIFF
--- a/app/src/main/java/com/mangoboss/app/api/controller/document/BossDocumentController.java
+++ b/app/src/main/java/com/mangoboss/app/api/controller/document/BossDocumentController.java
@@ -1,0 +1,38 @@
+package com.mangoboss.app.api.controller.document;
+
+import com.mangoboss.app.api.facade.document.BossDocumentFacade;
+import com.mangoboss.app.common.exception.CustomUserDetails;
+import com.mangoboss.app.dto.ListWrapperResponse;
+import com.mangoboss.app.dto.document.request.RequiredDocumentCreateRequest;
+import com.mangoboss.app.dto.document.response.RequiredDocumentResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/boss/stores/{storeId}/documents")
+@RequiredArgsConstructor
+@PreAuthorize("hasRole('BOSS')")
+public class BossDocumentController {
+
+    private final BossDocumentFacade bossDocumentFacade;
+
+    @PostMapping("/required")
+    public ListWrapperResponse<RequiredDocumentResponse> updateRequiredDocuments(@AuthenticationPrincipal final CustomUserDetails userDetails,
+                                                                                 @PathVariable final Long storeId,
+                                                                                 @RequestBody @Valid final List<RequiredDocumentCreateRequest> requestList) {
+        final Long bossId = userDetails.getUserId();
+        return ListWrapperResponse.of(bossDocumentFacade.updateRequiredDocuments(storeId, bossId, requestList));
+    }
+
+    @GetMapping("/required")
+    public ListWrapperResponse<RequiredDocumentResponse> getRequiredDocuments(@AuthenticationPrincipal final CustomUserDetails userDetails,
+                                                                              @PathVariable final Long storeId) {
+        final Long bossId = userDetails.getUserId();
+        return ListWrapperResponse.of(bossDocumentFacade.getRequiredDocuments(storeId, bossId));
+    }
+}

--- a/app/src/main/java/com/mangoboss/app/api/facade/document/BossDocumentFacade.java
+++ b/app/src/main/java/com/mangoboss/app/api/facade/document/BossDocumentFacade.java
@@ -1,0 +1,35 @@
+package com.mangoboss.app.api.facade.document;
+
+import com.mangoboss.app.domain.service.document.RequiredDocumentService;
+import com.mangoboss.app.domain.service.store.StoreService;
+import com.mangoboss.app.dto.document.request.RequiredDocumentCreateRequest;
+import com.mangoboss.app.dto.document.response.RequiredDocumentResponse;
+import com.mangoboss.storage.store.StoreEntity;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class BossDocumentFacade {
+
+    private final RequiredDocumentService requiredDocumentService;
+    private final StoreService storeService;
+
+    public List<RequiredDocumentResponse> updateRequiredDocuments(final Long storeId, final Long bossId, final List<RequiredDocumentCreateRequest> requests) {
+        final StoreEntity store = storeService.isBossOfStore(storeId, bossId);
+        requiredDocumentService.updateRequiredDocuments(store, requests);
+
+        return requiredDocumentService.findAllByStoreId(store.getId()).stream()
+                .map(RequiredDocumentResponse::fromEntity)
+                .toList();
+    }
+
+    public List<RequiredDocumentResponse> getRequiredDocuments(final Long storeId, final Long bossId) {
+        storeService.isBossOfStore(storeId, bossId);
+        return requiredDocumentService.findAllByStoreId(storeId).stream()
+                .map(RequiredDocumentResponse::fromEntity)
+                .toList();
+    }
+}

--- a/app/src/main/java/com/mangoboss/app/api/facade/store/BossStoreFacade.java
+++ b/app/src/main/java/com/mangoboss/app/api/facade/store/BossStoreFacade.java
@@ -1,5 +1,6 @@
 package com.mangoboss.app.api.facade.store;
 
+import com.mangoboss.app.domain.service.document.RequiredDocumentService;
 import com.mangoboss.app.domain.service.payroll.PayrollSettingService;
 import com.mangoboss.app.dto.store.response.*;
 import com.mangoboss.app.dto.store.request.StoreUpdateRequest;
@@ -27,6 +28,7 @@ public class BossStoreFacade {
 	private final StoreService storeService;
 	private final UserService userService;
 	private final PayrollSettingService payrollSettingService;
+	private final RequiredDocumentService requiredDocumentService;
 
 	@Transactional
 	public StoreCreateResponse createStore(final Long userId, final StoreCreateRequest request) {
@@ -34,6 +36,7 @@ public class BossStoreFacade {
 		storeService.validateBusinessNumber(request.businessNumber());
 		final StoreEntity saved = storeService.createStore(request, boss);
 		payrollSettingService.initPayrollSettingForStore(saved);
+		requiredDocumentService.initRequiredDocuments(saved);
 		return StoreCreateResponse.fromEntity(saved);
 	}
 

--- a/app/src/main/java/com/mangoboss/app/common/exception/CustomErrorInfo.java
+++ b/app/src/main/java/com/mangoboss/app/common/exception/CustomErrorInfo.java
@@ -55,6 +55,7 @@ public enum CustomErrorInfo {
     REGULAR_GROUP_NOT_FOUND(404, "해당하는 고정 근무 그룹이 없습니다.", 404007),
     ATTENDANCE_NOT_FOUND(404, "근태 정보가 없습니다.", 404008),
     CONTRACT_TEMPLATE_NOT_FOUND(404, "존재하지 않는 근로계약서 템플릿입니다.", 404009),
+    REQUIRED_DOCUMENT_NOT_FOUND(404, "요청한 제출 서류 설정이 존재하지 않습니다.", 404010),
 
     // 405 Method Not Allowed
     METHOD_NOT_ALLOWED(405, "HTTP 메서드가 잘못되었습니다.", 405001),

--- a/app/src/main/java/com/mangoboss/app/domain/repository/RequiredDocumentRepository.java
+++ b/app/src/main/java/com/mangoboss/app/domain/repository/RequiredDocumentRepository.java
@@ -1,0 +1,16 @@
+package com.mangoboss.app.domain.repository;
+
+import com.mangoboss.storage.document.DocumentType;
+import com.mangoboss.storage.document.RequiredDocumentEntity;
+import com.mangoboss.storage.store.StoreEntity;
+
+import java.util.List;
+
+public interface RequiredDocumentRepository {
+
+    List<RequiredDocumentEntity> findAllByStoreId(Long storeId);
+
+    RequiredDocumentEntity save(RequiredDocumentEntity entity);
+
+    RequiredDocumentEntity getByStoreAndDocumentType(StoreEntity store, DocumentType documentType);
+}

--- a/app/src/main/java/com/mangoboss/app/domain/service/document/RequiredDocumentService.java
+++ b/app/src/main/java/com/mangoboss/app/domain/service/document/RequiredDocumentService.java
@@ -1,0 +1,46 @@
+package com.mangoboss.app.domain.service.document;
+
+import com.mangoboss.app.domain.repository.RequiredDocumentRepository;
+import com.mangoboss.app.dto.document.request.RequiredDocumentCreateRequest;
+import com.mangoboss.storage.document.DocumentType;
+import com.mangoboss.storage.document.RequiredDocumentEntity;
+import com.mangoboss.storage.store.StoreEntity;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class RequiredDocumentService {
+
+    private final RequiredDocumentRepository requiredDocumentRepository;
+
+    @Transactional
+    public void updateRequiredDocuments(final StoreEntity store, final List<RequiredDocumentCreateRequest> requests) {
+        for (RequiredDocumentCreateRequest request : requests) {
+            final DocumentType documentType = request.documentType();
+            final boolean isRequired = request.isRequired();
+
+            final RequiredDocumentEntity existing = requiredDocumentRepository
+                    .getByStoreAndDocumentType(store, documentType);
+
+            existing.updateRequiredStatus(isRequired);
+            requiredDocumentRepository.save(existing);
+        }
+    }
+
+    @Transactional(readOnly = true)
+    public List<RequiredDocumentEntity> findAllByStoreId(final Long storeId) {
+        return requiredDocumentRepository.findAllByStoreId(storeId);
+    }
+
+    @Transactional
+    public void initRequiredDocuments(final StoreEntity store) {
+        for (DocumentType type : DocumentType.values()) {
+            final RequiredDocumentEntity requiredDoc = RequiredDocumentEntity.init(store, type);
+            requiredDocumentRepository.save(requiredDoc);
+        }
+    }
+}

--- a/app/src/main/java/com/mangoboss/app/dto/document/request/RequiredDocumentCreateRequest.java
+++ b/app/src/main/java/com/mangoboss/app/dto/document/request/RequiredDocumentCreateRequest.java
@@ -1,0 +1,15 @@
+package com.mangoboss.app.dto.document.request;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+
+import com.mangoboss.storage.document.DocumentType;
+
+@Builder
+public record RequiredDocumentCreateRequest(
+        @NotNull
+        DocumentType documentType,
+
+        @NotNull
+        Boolean isRequired
+) {}

--- a/app/src/main/java/com/mangoboss/app/dto/document/response/RequiredDocumentResponse.java
+++ b/app/src/main/java/com/mangoboss/app/dto/document/response/RequiredDocumentResponse.java
@@ -1,0 +1,18 @@
+package com.mangoboss.app.dto.document.response;
+
+import com.mangoboss.storage.document.DocumentType;
+import com.mangoboss.storage.document.RequiredDocumentEntity;
+import lombok.Builder;
+
+@Builder
+public record RequiredDocumentResponse(
+        DocumentType documentType,
+        boolean isRequired
+) {
+    public static RequiredDocumentResponse fromEntity(final RequiredDocumentEntity entity) {
+        return RequiredDocumentResponse.builder()
+                .documentType(entity.getDocumentType())
+                .isRequired(entity.isRequired())
+                .build();
+    }
+}

--- a/app/src/main/java/com/mangoboss/app/infra/persistence/RequiredDocumentRepositoryImpl.java
+++ b/app/src/main/java/com/mangoboss/app/infra/persistence/RequiredDocumentRepositoryImpl.java
@@ -1,0 +1,35 @@
+package com.mangoboss.app.infra.persistence;
+
+import com.mangoboss.app.common.exception.CustomErrorInfo;
+import com.mangoboss.app.common.exception.CustomException;
+import com.mangoboss.app.domain.repository.RequiredDocumentRepository;
+import com.mangoboss.storage.document.DocumentType;
+import com.mangoboss.storage.document.RequiredDocumentEntity;
+import com.mangoboss.storage.document.RequiredDocumentJpaRepository;
+import com.mangoboss.storage.store.StoreEntity;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class RequiredDocumentRepositoryImpl implements RequiredDocumentRepository {
+    private final RequiredDocumentJpaRepository requiredDocumentJpaRepository;
+
+    @Override
+    public RequiredDocumentEntity getByStoreAndDocumentType(final StoreEntity store, final DocumentType documentType) {
+        return requiredDocumentJpaRepository.findByStoreAndDocumentType(store, documentType)
+                .orElseThrow(() -> new CustomException(CustomErrorInfo.REQUIRED_DOCUMENT_NOT_FOUND));
+    }
+
+    @Override
+    public List<RequiredDocumentEntity> findAllByStoreId(Long storeId) {
+        return requiredDocumentJpaRepository.findAllByStoreId(storeId);
+    }
+
+    @Override
+    public RequiredDocumentEntity save(RequiredDocumentEntity entity) {
+        return requiredDocumentJpaRepository.save(entity);
+    }
+}

--- a/app/src/main/resources/data.sql
+++ b/app/src/main/resources/data.sql
@@ -26,6 +26,19 @@ INSERT INTO payroll_setting (payroll_setting_id, auto_transfer_enabled, overtime
                              transfer_account_id, store_id)
 VALUES (1, false, 0, 0, null, 1);
 
+INSERT INTO required_document (store_id, document_type, is_required, created_at, modified_at)
+VALUES(1, 'RESIDENT_REGISTRATION', false, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+      (1, 'BANK_ACCOUNT', false, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+      (1, 'ID_CARD', false, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+      (1, 'HEALTH_CERTIFICATE', false, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+      (2, 'RESIDENT_REGISTRATION', false, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+      (2, 'BANK_ACCOUNT', false, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+      (2, 'ID_CARD', false, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+      (2, 'HEALTH_CERTIFICATE', false, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+      (3, 'RESIDENT_REGISTRATION', false, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+      (3, 'BANK_ACCOUNT', false, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+      (3, 'ID_CARD', false, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+      (3, 'HEALTH_CERTIFICATE', false, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
 
 INSERT INTO staff (staff_id, user_id, store_id, name, profile_image_url, created_at, modified_at)
 VALUES (1, 2, 1, '망알바',

--- a/storage/src/main/java/com/mangoboss/storage/document/DocumentType.java
+++ b/storage/src/main/java/com/mangoboss/storage/document/DocumentType.java
@@ -1,0 +1,18 @@
+package com.mangoboss.storage.document;
+
+import lombok.Getter;
+
+@Getter
+public enum DocumentType {
+    RESIDENT_REGISTRATION("resident-registration/"), // 주민등록등본
+    HEALTH_CERTIFICATE("health-certificate/"), // 보건증
+    BANK_ACCOUNT("bank-account/"), // 통장 사본
+    ID_CARD("identification/"); // 신분증 사본
+
+    private final String folder;
+
+    DocumentType(final String folder) {
+        this.folder = folder;
+    }
+
+}

--- a/storage/src/main/java/com/mangoboss/storage/document/RequiredDocumentEntity.java
+++ b/storage/src/main/java/com/mangoboss/storage/document/RequiredDocumentEntity.java
@@ -1,0 +1,51 @@
+package com.mangoboss.storage.document;
+
+import com.mangoboss.storage.BaseTimeEntity;
+import com.mangoboss.storage.store.StoreEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "required_document")
+public class RequiredDocumentEntity extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "required_document_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "store_id", nullable = false)
+    private StoreEntity store;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "document_type", nullable = false)
+    private DocumentType documentType;
+
+    @Column(name = "is_required", nullable = false)
+    private boolean isRequired;
+
+    @Builder
+    private RequiredDocumentEntity(final StoreEntity store, final DocumentType documentType, final boolean isRequired) {
+        this.store = store;
+        this.documentType = documentType;
+        this.isRequired = isRequired;
+    }
+
+    public static RequiredDocumentEntity init(final StoreEntity store, final DocumentType documentType) {
+        return RequiredDocumentEntity.builder()
+                .store(store)
+                .documentType(documentType)
+                .isRequired(false)
+                .build();
+    }
+
+    public void updateRequiredStatus(final boolean isRequired) {
+        this.isRequired = isRequired;
+    }
+}

--- a/storage/src/main/java/com/mangoboss/storage/document/RequiredDocumentJpaRepository.java
+++ b/storage/src/main/java/com/mangoboss/storage/document/RequiredDocumentJpaRepository.java
@@ -1,0 +1,13 @@
+package com.mangoboss.storage.document;
+
+import com.mangoboss.storage.store.StoreEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface RequiredDocumentJpaRepository extends JpaRepository<RequiredDocumentEntity, Long> {
+    Optional<RequiredDocumentEntity> findByStoreAndDocumentType(StoreEntity store, DocumentType documentType);
+
+    List<RequiredDocumentEntity> findAllByStoreId(Long storeId);
+}


### PR DESCRIPTION
## 연관 이슈
> #44

### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가  
- [ ] 기능 삭제  
- [ ] 버그 수정  
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

---

## 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요

- [x] 사장이 매장별 제출 서류 필수 여부를 일괄 설정할 수 있는 API 개발
- [x] 사장이 매장별 제출 서류 설정을 조회할 수 있는 API 구현
- [x] 매장 생성 시 기본 제출 서류 설정 자동 등록 처리

---