### PR TITLE
[#47] 알바생이 서명한 근로계약서는 삭제할 수 없도록 제한, 매장 근로계약서 조회시 반환 형식 변경

### DIFF
--- a/app/src/main/java/com/mangoboss/app/api/facade/contract/BossContractFacade.java
+++ b/app/src/main/java/com/mangoboss/app/api/facade/contract/BossContractFacade.java
@@ -131,18 +131,16 @@ public class BossContractFacade {
         List<StaffEntity> staffs = staffService.getStaffsForStore(storeId);
         List<ContractEntity> contracts = contractService.findAllByStoreId(storeId);
 
-        Map<Long, ContractEntity> contractMap = contracts.stream()
-                .collect(Collectors.toMap(ContractEntity::getStaffId, Function.identity()));
+        Map<Long, List<ContractEntity>> contractMap = contracts.stream()
+                .collect(Collectors.groupingBy(ContractEntity::getStaffId));
 
         return staffs.stream()
                 .map(staff -> {
-                    ContractEntity contract = contractMap.get(staff.getId());
-                    if (contract == null) {
-                        return ContractSummaryResponse.fromStaffOnly(staff);
-                    }
-                    return ContractSummaryResponse.fromEntity(contract, staff);
+                    List<ContractEntity> staffContracts = contractMap.getOrDefault(staff.getId(), List.of());
+                    return ContractSummaryResponse.of(staff, staffContracts);
                 })
                 .toList();
+
     }
 
     public List<ContractSimpleResponse> getContractsByStaff(final Long storeId, final Long bossId, final Long staffId) {

--- a/app/src/main/java/com/mangoboss/app/api/facade/contract/BossContractFacade.java
+++ b/app/src/main/java/com/mangoboss/app/api/facade/contract/BossContractFacade.java
@@ -85,14 +85,11 @@ public class BossContractFacade {
         storeService.isBossOfStore(storeId, bossId);
         final ContractEntity contract = contractService.getContractById(contractId);
 
-        s3FileManager.deleteFile(contract.getFileKey());
-        if (contract.getStaffSignatureKey() != null) {
-            s3FileManager.deleteFile(contract.getStaffSignatureKey());
-        }
+        contractService.validateContractNotSignedByStaff(contract);
 
+        s3FileManager.deleteFile(contract.getFileKey());
         contractService.deleteContract(contractId);
     }
-
 
     public ContractTemplateResponse createContractTemplate(final Long storeId, final Long bossId, final ContractTemplateCreateRequest request) {
         storeService.isBossOfStore(storeId, bossId);

--- a/app/src/main/java/com/mangoboss/app/common/exception/CustomErrorInfo.java
+++ b/app/src/main/java/com/mangoboss/app/common/exception/CustomErrorInfo.java
@@ -34,6 +34,8 @@ public enum CustomErrorInfo {
     TRANSFER_DATE_EXCEEDED_EXCEPTION(400, "이미 급여 지급일이 지났습니다.", 400026),
     AUTO_TRANSFER_IS_NOT_ENABLED(400, "자동 송금이 설정되어 있지 않습니다.", 400027),
     DOCUMENT_ALREADY_UPLOADED(400, "이미 업로드한 서류입니다.", 400028),
+    STAFF_SIGNED_CONTRACT_CANNOT_BE_DELETED(400, "알바생이 서명한 근로계약서는 삭제할 수 없습니다.", 400029),
+
 
     // 401 Unauthorized
     LOGIN_NEEDED(401, "로그인이 필요합니다.", 401001),

--- a/app/src/main/java/com/mangoboss/app/domain/service/contract/ContractService.java
+++ b/app/src/main/java/com/mangoboss/app/domain/service/contract/ContractService.java
@@ -83,6 +83,11 @@ public class ContractService {
         contractRepository.delete(contract);
     }
 
+    public void validateContractNotSignedByStaff(final ContractEntity contract) {
+        if (contract.getStaffSignatureKey() != null) {
+            throw new CustomException(CustomErrorInfo.STAFF_SIGNED_CONTRACT_CANNOT_BE_DELETED);
+        }
+    }
 
     public ContractData convertFromContractDataJson(final String contractDataJson) {
         return JsonConverter.fromJson(contractDataJson, ContractData.class);

--- a/app/src/main/java/com/mangoboss/app/dto/contract/response/ContractSummaryResponse.java
+++ b/app/src/main/java/com/mangoboss/app/dto/contract/response/ContractSummaryResponse.java
@@ -2,34 +2,24 @@ package com.mangoboss.app.dto.contract.response;
 
 import com.mangoboss.app.dto.staff.response.StaffSimpleResponse;
 import com.mangoboss.storage.contract.ContractEntity;
-import com.mangoboss.storage.contract.ContractStatus;
 import com.mangoboss.storage.staff.StaffEntity;
 import lombok.Builder;
 
-import java.time.LocalDateTime;
+import java.util.List;
 
 @Builder
 public record ContractSummaryResponse(
-        Long contractId,
-        LocalDateTime modifiedAt,
-        ContractStatus status,
-        StaffSimpleResponse staff
+        StaffSimpleResponse staffSimpleResponse,
+        List<ContractSimpleResponse> contractSimpleResponses
 ) {
-    public static ContractSummaryResponse fromStaffOnly(final StaffEntity staff) {
+    public static ContractSummaryResponse of(StaffEntity staff, List<ContractEntity> contracts) {
         return ContractSummaryResponse.builder()
-                .contractId(null)
-                .modifiedAt(null)
-                .status(ContractStatus.NOT_CREATED)
-                .staff(StaffSimpleResponse.fromEntity(staff))
-                .build();
-    }
-
-    public static ContractSummaryResponse fromEntity(final ContractEntity contract, final StaffEntity staff) {
-        return ContractSummaryResponse.builder()
-                .contractId(contract.getId())
-                .modifiedAt(contract.getModifiedAt())
-                .status(contract.getStatus())
-                .staff(StaffSimpleResponse.fromEntity(staff))
+                .staffSimpleResponse(StaffSimpleResponse.fromEntity(staff))
+                .contractSimpleResponses(
+                        contracts.stream()
+                                .map(ContractSimpleResponse::fromEntity)
+                                .toList()
+                )
                 .build();
     }
 }


### PR DESCRIPTION
## 연관 이슈
> #47

### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가  
- [ ] 기능 삭제  
- [ ] 버그 수정  
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

---

## 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요

- [x] 알바생이 서명한 근로계약서는 삭제할 수 없도록 제한
- [x] 매장 근로계약서 조회 시 알바생 단위로 계약서 그룹화
---