### PR TITLE
[#47] 근로계약서 PDF 무결성 검증 로직 추가

### DIFF
--- a/app/src/main/java/com/mangoboss/app/api/facade/contract/BossContractFacade.java
+++ b/app/src/main/java/com/mangoboss/app/api/facade/contract/BossContractFacade.java
@@ -22,7 +22,6 @@ import org.springframework.stereotype.Service;
 
 import java.util.List;
 import java.util.Map;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 
 @Service
@@ -57,12 +56,14 @@ public class BossContractFacade {
     public ViewPreSignedUrlResponse getContractViewUrl(final Long storeId, final Long bossId, final Long contractId) {
         storeService.isBossOfStore(storeId, bossId);
         final ContractEntity contract = contractService.getContractById(contractId);
+        contractService.validatePdfIntegrity(contract);
         return s3FileManager.generateViewPreSignedUrl(contract.getFileKey());
     }
 
     public DownloadPreSignedUrlResponse getContractDownloadUrl(final Long storeId, final Long bossId, final Long contractId) {
         storeService.isBossOfStore(storeId, bossId);
         final ContractEntity contract = contractService.getContractById(contractId);
+        contractService.validatePdfIntegrity(contract);
         return s3FileManager.generateDownloadPreSignedUrl(contract.getFileKey());
     }
 

--- a/app/src/main/java/com/mangoboss/app/api/facade/contract/StaffContractFacade.java
+++ b/app/src/main/java/com/mangoboss/app/api/facade/contract/StaffContractFacade.java
@@ -57,6 +57,9 @@ public class StaffContractFacade {
         final StaffEntity staff = staffService.getVerifiedStaff(userId, storeId);
         final ContractEntity contract = contractService.getContractById(contractId);
         contractService.validateContractBelongsToStaff(contract.getStaffId(), staff.getId());
+
+        contractService.validatePdfIntegrity(contract);
+
         return s3FileManager.generateViewPreSignedUrl(contract.getFileKey());
     }
 
@@ -64,6 +67,9 @@ public class StaffContractFacade {
         final StaffEntity staff = staffService.getVerifiedStaff(userId, storeId);
         final ContractEntity contract = contractService.getContractById(contractId);
         contractService.validateContractBelongsToStaff(contract.getStaffId(), staff.getId());
+
+        contractService.validatePdfIntegrity(contract);
+
         return s3FileManager.generateDownloadPreSignedUrl(contract.getFileKey());
     }
 

--- a/app/src/main/java/com/mangoboss/app/common/exception/CustomErrorInfo.java
+++ b/app/src/main/java/com/mangoboss/app/common/exception/CustomErrorInfo.java
@@ -64,6 +64,9 @@ public enum CustomErrorInfo {
     DOCUMENT_NOT_BELONG_TO_STAFF(403, "이 서류는 해당 알바생의 서류가 아닙니다.", 403006),
     FORBIDDEN_TASK_LOG_DELETE(403, "해당 업무 완료 기록을 삭제할 권한이 없습니다.", 403007),
 
+    // 422 Unprocessable Entity
+    CONTRACT_PDF_TAMPERED(422, "계약서 PDF의 무결성이 손상되었습니다.", 422001),
+
     // 404 Not Found
     USER_NOT_FOUND(404, "사용자를 찾을 수 없습니다.", 404001),
     KAKAO_USER_INFO_NOT_FOUND(404, "카카오 사용자 정보 없음", 404002),
@@ -111,7 +114,8 @@ public enum CustomErrorInfo {
     EXTERNAL_API_LOGICAL_FAILURE(500, "외부 서비스 요청은 성공했지만 처리에 실패했습니다.", 500011),
     UNMAPPED_DEDUCTION_UNIT_EXCEPTION(500, "서버 내부 데이터에 알 수 없는 상태 코드가 포함되어 있어 처리할 수 없습니다.", 500012),
     FILE_UPLOAD_FAILED(500, "파일 업로드에 실패했습니다.", 500013),
-    FILE_DELETE_FAILED(500, "파일 삭제에 실패했습니다.", 500014);
+    FILE_DELETE_FAILED(500, "파일 삭제에 실패했습니다.", 500014),
+    DIGEST_FAILURE(500, "SHA-256 해시 생성에 실패했습니다", 500015);
 
     private final int statusCode;
     private final String message;

--- a/app/src/main/java/com/mangoboss/app/common/util/DigestUtil.java
+++ b/app/src/main/java/com/mangoboss/app/common/util/DigestUtil.java
@@ -1,0 +1,26 @@
+package com.mangoboss.app.common.util;
+
+import com.mangoboss.app.common.exception.CustomErrorInfo;
+import com.mangoboss.app.common.exception.CustomException;
+import org.springframework.stereotype.Component;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+@Component
+public class DigestUtil {
+
+    public static String sha256(final byte[] content) {
+        try {
+            final MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            final byte[] hashBytes = digest.digest(content);
+            final StringBuilder sb = new StringBuilder();
+            for (byte b : hashBytes) {
+                sb.append(String.format("%02x", b));
+            }
+            return sb.toString();
+        } catch (NoSuchAlgorithmException e) {
+            throw new CustomException(CustomErrorInfo.DIGEST_FAILURE);
+        }
+    }
+}

--- a/app/src/main/java/com/mangoboss/app/common/util/S3FileManager.java
+++ b/app/src/main/java/com/mangoboss/app/common/util/S3FileManager.java
@@ -1,5 +1,6 @@
 package com.mangoboss.app.common.util;
 
+import com.mangoboss.app.common.constant.ContentType;
 import com.mangoboss.app.common.constant.S3FileType;
 import com.mangoboss.app.common.exception.CustomErrorInfo;
 import com.mangoboss.app.common.exception.CustomException;
@@ -68,6 +69,16 @@ public class S3FileManager {
         s3Client.putObject(request, RequestBody.fromBytes(fileData));
     }
 
+    public void upload(String key, byte[] fileBytes, ContentType contentType) {
+        final PutObjectRequest request = PutObjectRequest.builder()
+                .bucket(contractBucketName)
+                .key(key)
+                .contentType(contentType.getMimeType())
+                .build();
+
+        s3Client.putObject(request, RequestBody.fromBytes(fileBytes));
+    }
+
     public void deleteFile(final String key) {
         try {
             final DeleteObjectRequest deleteRequest = DeleteObjectRequest.builder()
@@ -89,7 +100,7 @@ public class S3FileManager {
     }
 
     // s3에서 서명 파일 가져옴
-    private byte[] fetchAsBytes(final String key) {
+    public byte[] fetchAsBytes(final String key) {
         try {
             final ResponseBytes<GetObjectResponse> objectBytes = s3Client.getObjectAsBytes(
                     GetObjectRequest.builder()

--- a/storage/src/main/java/com/mangoboss/storage/contract/ContractEntity.java
+++ b/storage/src/main/java/com/mangoboss/storage/contract/ContractEntity.java
@@ -39,6 +39,9 @@ public class ContractEntity extends BaseTimeEntity {
 
     private LocalDateTime staffSignedAt;
 
+    @Column(nullable = false)
+    private String pdfHash;
+
     @Lob
     @Column(name = "contract_data_json", columnDefinition = "MEDIUMTEXT", nullable = false)
     private String contractDataJson;
@@ -46,7 +49,7 @@ public class ContractEntity extends BaseTimeEntity {
     @Builder
     private ContractEntity(final Long staffId, final String fileKey, final String bossSignatureKey,
                            final ContractStatus status, final LocalDateTime bossSignedAt, final LocalDateTime staffSignedAt,
-                           final String contractDataJson) {
+                           final String contractDataJson, final String pdfHash) {
         this.staffId = staffId;
         this.fileKey = fileKey;
         this.bossSignatureKey = bossSignatureKey;
@@ -54,11 +57,12 @@ public class ContractEntity extends BaseTimeEntity {
         this.bossSignedAt = bossSignedAt;
         this.staffSignedAt = staffSignedAt;
         this.contractDataJson = contractDataJson;
+        this.pdfHash = pdfHash;
     }
 
     // 계약 생성 (초안 상태)
     public static ContractEntity create(final Long staffId, final String fileKey, final String contractDataJson,
-                                        final String bossSignatureKey, final LocalDateTime bossSignedAt) {
+                                        final String bossSignatureKey, final LocalDateTime bossSignedAt, final String pdfHash) {
         return ContractEntity.builder()
                 .staffId(staffId)
                 .fileKey(fileKey)
@@ -66,15 +70,18 @@ public class ContractEntity extends BaseTimeEntity {
                 .bossSignatureKey(bossSignatureKey)
                 .bossSignedAt(bossSignedAt)
                 .status(ContractStatus.PENDING_STAFF_SIGNATURE)
+                .pdfHash(pdfHash)
                 .build();
     }
 
     // 알바생 서명 완료 처리
-    public ContractEntity completeStaffSign(final String signedFileKey, final String staffSignatureKey, final LocalDateTime signedAt) {
+    public ContractEntity completeStaffSign(final String signedFileKey, final String staffSignatureKey,
+                                            final LocalDateTime signedAt, final String staffSignedPdfHash) {
         this.fileKey = signedFileKey;
         this.staffSignatureKey = staffSignatureKey;
         this.staffSignedAt = signedAt;
         this.status = ContractStatus.COMPLETED;
+        this.pdfHash = staffSignedPdfHash;
         return this;
     }
 


### PR DESCRIPTION
## 연관 이슈
> #47

### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가  
- [ ] 기능 삭제  
- [ ] 버그 수정  
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

---

## 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요

- [x] 근로계약서 PDF 무결성 검증 로직 추가
- [x] S3에 저장된 근로계약서 PDF의 바이트를 SHA-256 해시로 변환 후 기존 DB에 저장된 PDF 해시 값 비교하여 위변조 여부 확인
- [x] 최종 근로계약서 PDF 손상시 에러 반환
---