### PR TITLE
[Release] 알바생 업무 완료 시 TaskLog에 잘못된 staffId 저장 문제 수정 (hotfix)

### DIFF
--- a/app/src/main/java/com/mangoboss/app/api/facade/task/StaffTaskFacade.java
+++ b/app/src/main/java/com/mangoboss/app/api/facade/task/StaffTaskFacade.java
@@ -9,6 +9,7 @@ import com.mangoboss.app.dto.task.request.TaskCheckRequest;
 import com.mangoboss.app.dto.task.response.AssignedTaskResponse;
 import com.mangoboss.app.dto.task.response.TaskLogDetailResponse;
 import com.mangoboss.storage.metadata.S3FileType;
+import com.mangoboss.storage.staff.StaffEntity;
 import com.mangoboss.storage.task.TaskEntity;
 import com.mangoboss.storage.task.TaskLogEntity;
 import lombok.RequiredArgsConstructor;
@@ -28,8 +29,8 @@ public class StaffTaskFacade {
     private final S3PreSignedUrlManager s3PreSignedUrlManager;
 
     public void completeTask(final Long storeId, final Long taskId, final Long userId, final TaskCheckRequest request) {
-        staffService.getVerifiedStaff(userId, storeId);
-        taskService.completeTask(storeId, taskId, userId, request.reportImageUrl());
+        StaffEntity staff = staffService.getVerifiedStaff(userId, storeId);
+        taskService.completeTask(storeId, taskId, staff.getId(), request.reportImageUrl());
     }
 
     public void cancelCompleteTask(final Long storeId, final Long taskId, final Long userId) {


### PR DESCRIPTION
## 연관 이슈
> #71 

### PR 타입(하나 이상의 PR 타입을 선택해주세요)
-[ ] 기능 추가  
-[ ] 기능 삭제  
-[x] 버그 수정  
-[ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

---

## 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요

- [ ] 알바생 업무 완료 시 TaskLog에 잘못된 staffId 저장 문제 수정 (hotfix)

---
## 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요